### PR TITLE
Add Helm Support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
 
       - uses: actions/setup-go@v2
 
-      - name: Generate Recommended YAML
-        run: make dist
+      - name: Generate Helm Chart and Recommended YAML
+        run: make dist charts
         env:
           VERSION: ${{ steps.extract.outputs.version }}
 
@@ -53,3 +53,8 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/recommended.yaml
           tag: ${{ github.ref }}
+
+      - name: Publish Helm Chart
+        run: ./hack/helm/deploy-pages.sh ./doppler-kubernetes-operator*.tgz
+        env:
+          PRIVATE_KEY: ${{ secrets.CHARTS_DEPLOY_PRIVATE_KEY }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ testbin/*
 *.swp
 *.swo
 *~
+
+# outputs
+/dist/
+/charts/
+/*.tgz

--- a/README.md
+++ b/README.md
@@ -19,13 +19,26 @@ Kubernetes Secrets are, by default, stored as unencrypted base64-encoded strings
 
 ## Step 1: Deploy the Operator
 
-Deploy the operator by applying the latest installation YAML:
+### Using Helm
+
+You can install the latest Helm chart with:
+
+```bash
+helm repo add doppler https://helm.doppler.com
+helm install --generate-name doppler/doppler-kubernetes-operator
+```
+
+Updates can be performed with `helm upgrade`.
+
+### Using `kubectl`
+
+You can also deploy the operator by applying the latest installation YAML directly:
 
 ```bash
 kubectl apply -f https://github.com/DopplerHQ/kubernetes-operator/releases/latest/download/recommended.yaml
 ```
 
-This will use your locally-configured `kubectl` to:
+Regardless of the installation method, this will use your locally-configured `kubectl` to:
 
 - Create a `doppler-operator-system` namespace
 - Create the resource definition for a `DopplerSecret`
@@ -232,7 +245,7 @@ kubectl delete dopplersecrets --all --all-namespaces
 kubectl delete secret doppler-token-secret -n doppler-operator-system
 ```
 
-Then, run the following command to delete all of the resources created during the initial installation:
+If you installed the operator with Helm, you can use `helm uninstall` to remove the installation resources. Otherwise, run the following command:
 
 ```bash
 kubectl delete -f https://github.com/DopplerHQ/kubernetes-operator/releases/latest/download/recommended.yaml

--- a/hack/helm/Chart.yaml
+++ b/hack/helm/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: doppler-kubernetes-operator
+version: v1.0.0
+description: Automatically sync secrets from Doppler to Kubernetes and auto-reload deployments when secrets change.
+keywords:
+  - Doppler
+  - Secrets Manager
+home: https://doppler.com
+sources:
+  - https://github.com/DopplerHQ/kubernetes-operator
+icon: https://doppler.com/imgs/logo_color.png

--- a/hack/helm/NOTES.txt
+++ b/hack/helm/NOTES.txt
@@ -1,0 +1,1 @@
+To configure the Doppler operator, see https://github.com/DopplerHQ/kubernetes-operator

--- a/hack/helm/deploy-pages.sh
+++ b/hack/helm/deploy-pages.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -euo pipefail
+
+tmpDir=$(mktemp -d)
+
+function cleanup() {
+	rm -r "$tmpDir"
+	echo "Deleted $tmpDir"
+}
+trap cleanup EXIT
+
+# TEMP/charts will contain our new chart
+mkdir "$tmpDir/charts"
+cp "$1" "$tmpDir/charts"
+pushd "$tmpDir"
+
+# TEMP/key will contain our private SSH key
+keyFile="${tmpDir}/key"
+echo "${PRIVATE_KEY}" > "$keyFile"
+chmod 600 "$keyFile"
+
+# TEMP/helm-charts will be our cloned repo
+gitSSHCommand="ssh -i ${keyFile} -o IdentitiesOnly=yes"
+GIT_SSH_COMMAND="${gitSSHCommand}" git clone git@github.com:DopplerHQ/helm-charts
+cd helm-charts
+
+git config user.name "Doppler Bot"
+git config user.email "support@doppler.com"
+
+if [[ -f "index.yaml" ]]; then
+	echo "Found index, merging changes"
+	# Ugly workaround to preserve old file timestamps: https://github.com/helm/helm/issues/7363#issuecomment-572369872
+	# Generate the index from TEMP/charts (which only contains our new chart) and merge in the existing index
+	helm repo index ../charts --url https://helm.doppler.com --merge index.yaml
+	# Then copy the index.yaml and the new chart to TEMP/helm-charts
+	mv ../charts/* ./
+else
+	echo "No index found, generating a new one"
+	# Copy new chart TEMP/helm-charts
+	mv ../charts/* ./
+	# Generate the new index in this dir with the new chart
+	helm repo index . --url https://helm.doppler.com
+fi
+
+git add .
+git commit -m "Publish Helm charts"
+GIT_SSH_COMMAND="${gitSSHCommand}" git push
+
+popd


### PR DESCRIPTION
This PR:

- Adds a `make charts` target to build a Helm chart tarball
    - We're using `kustomize` (via the Operator SDK) to build our k8s yaml today and it's difficult to get these resources into separate files without losing our patches.
    - Instead, we're using `yq` (the yaml equivalent of `jq`) to extract just the CRD files which need to be [placed in a different directory](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/)
- Adds a step to our release action to upload the chart tarball to DopplerHQ/helm-charts (hosted as https://helm.doppler.com) and add the file to the `index.yaml` file

I tested the action from this branch by temporarily modifying the trigger to run on every push. As a result, the current helm chart is available on https://helm.doppler.com so you can actually give it a try if you like!