### PR TITLE
Remove Prerelease Label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Doppler Kubernetes Operator (Prerelease)
+# Doppler Kubernetes Operator
 
 Automatically sync secrets from Doppler to Kubernetes and auto-reload deployments when secrets change.
 


### PR DESCRIPTION
After some internal evaluation, we've decided to move the operator out of "prerelease" status. The main drivers for this decision were:

- The number of Doppler users actively using the operator
- The number of requests made by the operator to the Doppler API
- The feedback received and re-incorporated by users of the operator