### PR TITLE
Add support for downloading secrets as files for mounting inside containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ One caveat is that [Helm cannot update custom resource definitions (CRDs)](https
 To simplify this, Doppler guarantees that CRDs will remain backwards compatible. CRDs can be updated directly from the Helm chart manifest with:
 
 ```bash
+helm repo update
 helm pull doppler/doppler-kubernetes-operator --untar
 kubectl apply -f doppler-kubernetes-operator/crds/all.yaml
 ```

--- a/api/v1alpha1/dopplersecret_types.go
+++ b/api/v1alpha1/dopplersecret_types.go
@@ -78,6 +78,11 @@ type DopplerSecretSpec struct {
 	// +optional
 	NameTransformer string `json:"nameTransformer,omitempty"`
 
+	// Format enables the downloading of secrets as a file
+	// +kubebuilder:validation:Enum=json;dotnet-json;env;yaml;docker
+	// +optional
+	Format string `json:"format,omitempty"`
+
 	// The number of seconds to wait between resyncs
 	// +kubebuilder:default=60
 	ResyncSeconds int64 `json:"resyncSeconds,omitempty"`

--- a/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
+++ b/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
@@ -39,6 +39,15 @@ spec:
               config:
                 description: The Doppler config
                 type: string
+              format:
+                description: Format enables the downloading of secrets as a file
+                enum:
+                - json
+                - dotnet-json
+                - env
+                - yaml
+                - docker
+                type: string
               host:
                 default: https://api.doppler.com
                 description: The Doppler API host

--- a/pkg/models/secrets.go
+++ b/pkg/models/secrets.go
@@ -1,10 +1,5 @@
 package models
 
-import (
-	"encoding/json"
-	"sort"
-)
-
 type Secret struct {
 	Name  string
 	Value string
@@ -14,26 +9,4 @@ type SecretsResult struct {
 	Modified bool
 	Secrets  []Secret
 	ETag     string
-}
-
-func ParseSecrets(statusCode int, response []byte, eTag string) (*SecretsResult, error) {
-	if statusCode == 304 {
-		return &SecretsResult{Modified: false, Secrets: nil, ETag: ""}, nil
-	}
-
-	var result map[string]string
-	err := json.Unmarshal(response, &result)
-	if err != nil {
-		return nil, err
-	}
-
-	secrets := make([]Secret, 0)
-	for key, value := range result {
-		secret := Secret{Name: key, Value: value}
-		secrets = append(secrets, secret)
-	}
-	sort.Slice(secrets, func(i, j int) bool {
-		return secrets[i].Name < secrets[j].Name
-	})
-	return &SecretsResult{Modified: true, Secrets: secrets, ETag: eTag}, nil
 }


### PR DESCRIPTION
Instead of the standard Key / Value pairs, you can download secrets as a single file, enabling you to mount the downloaded file contents in a container.

https://user-images.githubusercontent.com/133014/191739516-fe1a6113-6da9-46c2-9d75-e765e9946542.mp4

Closes DEVRL-290