### PR TITLE
Lock go version to 1.16

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,8 @@ jobs:
         run: echo ${{ steps.docker_build.outputs.digest }}
 
       - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
 
       - name: Generate Helm Chart and Recommended YAML
         run: make dist charts

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DopplerHQ/kubernetes-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/go-logr/logr v0.3.0


### PR DESCRIPTION
1.16 was already specified in the Dockerfile but was inconsistently defined in other areas.

I tried upgrading to a later Go version but there are some dependencies which will need to be massaged. I've filed internal issue ENG-5809 to do this work at a later time.