### PR TITLE
Add write contents permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The release job needs write access to the repo contents so it can upload the `recommended.yaml` artifact to the GitHub release.