### PR TITLE
Adjust requested memory resource size from 128Mi to 256Mi for operator manager 

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,6 +56,6 @@ spec:
             memory: 256Mi
           requests:
             cpu: 100m
-            memory: 128Mi
+            memory: 256Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
We were facing OOM restarts after updating the kubernetes operator.
Turned out that the memory requests were too low on GCP Autopilot for the amount of secrets we have.

After updating the memory requests to 256mb, the system recovered with the new features.