### PR TITLE
Update deprecated GitHub set-output syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Extract Version
         id: extract
-        run: echo ::set-output name=version::${GITHUB_REF#refs/*/v}
+        run: echo "version=${GITHUB_REF#refs/*/v}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
GitHub has deprecated the `set-output` syntax and [although they aren't breaking the functionality as soon as they planned](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), they might do it in the near future.