### PR TITLE
Allow reconciliation of dopplersecret resources with refs in same namespace

### DIFF
--- a/controllers/dopplersecret_controller.go
+++ b/controllers/dopplersecret_controller.go
@@ -63,13 +63,6 @@ func (r *DopplerSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		}, nil
 	}
 
-	if ownNamespace != req.Namespace {
-		log.Error(fmt.Errorf("cannot reconcile doppler secret (%v) in a namespace different from the operator (%v)", req.NamespacedName, ownNamespace), "")
-		return ctrl.Result{}, nil
-	}
-
-	log.Info("Reconciling dopplersecret")
-
 	dopplerSecret := secretsv1alpha1.DopplerSecret{}
 	err := r.Client.Get(ctx, req.NamespacedName, &dopplerSecret)
 	if err != nil {
@@ -82,6 +75,29 @@ func (r *DopplerSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			RequeueAfter: defaultRequeueDuration,
 		}, nil
 	}
+
+	// If omitted, the default namespace for references is the DopplerSecret's namespace
+	tokenSecretRefNamespace := dopplerSecret.Spec.TokenSecretRef.Namespace
+	if tokenSecretRefNamespace == "" {
+		tokenSecretRefNamespace = dopplerSecret.Namespace
+	}
+	managedSecretRefNamespace := dopplerSecret.Spec.ManagedSecretRef.Namespace
+	if managedSecretRefNamespace == "" {
+		managedSecretRefNamespace = dopplerSecret.Namespace
+	}
+
+	if ownNamespace == dopplerSecret.Namespace {
+		log.Info("Reconciling dopplersecret in operator namespace, references can be in any namespace.")
+	} else if dopplerSecret.Namespace == tokenSecretRefNamespace && dopplerSecret.Namespace == managedSecretRefNamespace {
+		log.Info("Reconciling dopplersecret in non-operator namespace, all references are in the same namespace as the dopplersecret.")
+	} else {
+		p1 := fmt.Sprintf("cannot reconcile dopplersecret (%v/%v) in a namespace different from the operator (%v)", dopplerSecret.Namespace, dopplerSecret.Name, ownNamespace)
+		p2 := fmt.Sprintf("unless all secret references [(%v/%v), (%v/%v)] are also in the dopplersecret's namespace", tokenSecretRefNamespace, dopplerSecret.Spec.TokenSecretRef.Name, managedSecretRefNamespace, dopplerSecret.Spec.ManagedSecretRef.Name)
+		log.Error(fmt.Errorf("%v %v", p1, p2), "")
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("Reconciling dopplersecret")
 
 	requeueAfter := defaultRequeueDuration
 	if dopplerSecret.Spec.ResyncSeconds != 0 {


### PR DESCRIPTION
This PR updates the reconciliation behavior introduced in v1.2.0 to accommodate multi-tenancy use cases.

Before v1.2.0, the operator could reconcile a DopplerSecret in any namespace with references to secrets in any other namespaces. This posed [a security risk](https://github.com/DopplerHQ/kubernetes-operator/releases/tag/v1.2.0) because a user with access to a single namespace in the cluster could use the operator to read secrets from Doppler using token secrets that they couldn't read themselves.

In v1.2.0, the behavior was changed so that a DopplerSecret couldn't be reconciled unless it was in the same namespace as the operator itself (i.e. `doppler-operator-system`). This worked to address the security issue but made things significantly harder for teams with multi-tenant use cases.

This PR (which will likely ship in v1.3.0) updates the behavior again. DopplerSecrets in the operator's namespace behave as they did in v1.2.0, in that they can reference secrets in their own or any other namespaces. Additionally, the operator will reconcile DopplerSecrets in other namespaces if all references are in the same namespace as the DopplerSecret itself. For example, a DopplerSecret in the `app1` namespace can reference token secrets and managed secrets in `app1` only.

Reminder: As a convenience, the namespace may be omitted from secret references in the DopplerSecret resource and the operator will use the DopplerSecret's namespace as the default. This behavior has been in place before v1.2.0 and has not changed.

Closes ENG-5089
Closes #45
Closes #31 
Closes #28

Thanks to all issue submitters for weighing in on this! If you feel that this behavior change won't work for your use cases, please let me know in your original issue and we can brainstorm.