### PR TITLE
Add support for syncing secret subsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Automatically sync secrets from Doppler to Kubernetes and auto-reload deployment
 
 ## Step 0: Enable Kubernetes Secret Encryption at Rest
 
-The Doppler Kubernetes Operator uses [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to store sensitive data. 
+The Doppler Kubernetes Operator uses [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) to store sensitive data.
 
 Kubernetes Secrets are, by default, stored as unencrypted base64-encoded strings. By default they can be retrieved - as plain text - by anyone with API access, or anyone with access to Kubernetes' underlying data store, etcd. Therefore, Kubernetes recommends enabling [encryption at rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) to secure this data.
 
@@ -281,6 +281,29 @@ You can then configure your deployment spec to mount the file at the desired pat
               - key: DOPPLER_SECRETS_FILE # Hard-coded by Operator when format specified
                 path: appsettings.json # Name or path to file name appended to container mountPath
 ```
+
+## Specifying Secret Subsets to Sync
+
+You can have the operator only sync a subset of secrets in a Doppler config. To do this, specify them in the `secrets` spec property:
+
+```yaml
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: dopplersecret-test
+  namespace: doppler-operator-system
+spec:
+  tokenSecret:
+    name: doppler-token-secret
+  secrets:
+    - HOSTNAME
+    - PORT
+  managedSecret:
+    name: doppler-test-secret
+    namespace: default
+```
+
+If this property is omitted all secrets are synced.
 
 ## Kubernetes Secret Types and Value Encoding
 

--- a/api/v1alpha1/dopplersecret_types.go
+++ b/api/v1alpha1/dopplersecret_types.go
@@ -82,6 +82,10 @@ type DopplerSecretSpec struct {
 	// +optional
 	Config string `json:"config,omitempty"`
 
+	// A list of secrets to sync from the config
+	// +optional
+	Secrets []string `json:"secrets,omitempty"`
+
 	// A list of processors to transform the data during ingestion
 	// +kubebuilder:default={}
 	Processors SecretProcessors `json:"processors,omitempty"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *DopplerSecretSpec) DeepCopyInto(out *DopplerSecretSpec) {
 	*out = *in
 	out.TokenSecretRef = in.TokenSecretRef
 	out.ManagedSecretRef = in.ManagedSecretRef
+	if in.Secrets != nil {
+		in, out := &in.Secrets, &out.Secrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Processors != nil {
 		in, out := &in.Processors, &out.Processors
 		*out = make(SecretProcessors, len(*in))

--- a/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
+++ b/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
@@ -118,6 +118,11 @@ spec:
                 description: The number of seconds to wait between resyncs
                 format: int64
                 type: integer
+              secrets:
+                description: A list of secrets to sync from the config
+                items:
+                  type: string
+                type: array
               tokenSecret:
                 description: The Kubernetes secret containing the Doppler service
                   token

--- a/controllers/dopplersecret_controller_secrets.go
+++ b/controllers/dopplersecret_controller_secrets.go
@@ -276,7 +276,7 @@ func (r *DopplerSecretReconciler) UpdateSecret(ctx context.Context, dopplerSecre
 		requestedSecretVersion = ""
 	}
 
-	secretsResult, apiErr := api.GetSecrets(GetAPIContext(dopplerSecret, dopplerToken), requestedSecretVersion, dopplerSecret.Spec.Project, dopplerSecret.Spec.Config, dopplerSecret.Spec.NameTransformer, dopplerSecret.Spec.Format)
+	secretsResult, apiErr := api.GetSecrets(GetAPIContext(dopplerSecret, dopplerToken), requestedSecretVersion, dopplerSecret.Spec.Project, dopplerSecret.Spec.Config, dopplerSecret.Spec.NameTransformer, dopplerSecret.Spec.Format, dopplerSecret.Spec.Secrets)
 	if apiErr != nil {
 		return apiErr
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -125,7 +125,7 @@ func PerformRequest(context APIContext, req *http.Request) (*APIResponse, *APIEr
 	return response, nil
 }
 
-func GetSecrets(context APIContext, lastETag string, project string, config string, nameTransformer string, format string) (*models.SecretsResult, *APIError) {
+func GetSecrets(context APIContext, lastETag string, project string, config string, nameTransformer string, format string, secrets []string) (*models.SecretsResult, *APIError) {
 	headers := map[string]string{}
 	if lastETag != "" {
 		headers["If-None-Match"] = lastETag
@@ -137,6 +137,9 @@ func GetSecrets(context APIContext, lastETag string, project string, config stri
 	}
 	if config != "" {
 		params = append(params, QueryParam{Key: "config", Value: config})
+	}
+	if len(secrets) > 0 {
+		params = append(params, QueryParam{Key: "secrets", Value: strings.Join(secrets, ",")})
 	}
 	if nameTransformer != "" {
 		params = append(params, QueryParam{Key: "name_transformer", Value: nameTransformer})


### PR DESCRIPTION
This adds the ability to specify a list of secrets you'd like to have synced from the config to the k8s secret. Prior to this, the only option was to either sync ALL secrets or use the `kubernetes.io/tls` DopplerSecret type combined with `processors`.

```yaml
apiVersion: secrets.doppler.com/v1alpha1
kind: DopplerSecret
metadata:
  name: dopplersecret-test
  namespace: doppler-operator-system
spec:
  tokenSecret:
    name: doppler-token-secret
  secrets:
    - HOSTNAME
    - PORT
  managedSecret:
    name: doppler-test-secret
    namespace: default
```

Fixes FEA-125