### PR TITLE
Log rate limits as info so they can be silenced

### DIFF
--- a/controllers/dopplersecret_controller.go
+++ b/controllers/dopplersecret_controller.go
@@ -113,7 +113,13 @@ func (r *DopplerSecretReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	err = r.UpdateSecret(ctx, dopplerSecret)
 	r.SetSecretsSyncReadyCondition(ctx, &dopplerSecret, err)
 	if err != nil {
-		log.Error(err, "Unable to update dopplersecret")
+		logMsg := "Unable to update dopplersecret"
+		// log rate limits at info level so they can be told apart from other errors and silenced by setting log level to error
+		if errors.IsTooManyRequests(err) {
+			log.WithValues("error", err).Info(logMsg)
+		} else {
+			log.Error(err, logMsg)
+		}
 		return ctrl.Result{
 			RequeueAfter: requeueAfter,
 		}, nil


### PR DESCRIPTION
Related to https://github.com/DopplerHQ/kubernetes-operator/issues/57 - rate limit logs are extremely spammy and the stack traces make them very verbose too. Considering that if rate limits are hit once they will be hit periodically, they are too noisy at error level.