### PR TITLE
Revert release toolchain Go update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 jobs:
   release:
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.22"
+          go-version: "1.20"
 
       - name: Generate Helm Chart and Recommended YAML
         run: make dist charts


### PR DESCRIPTION
The Go upgrade in #75 is causing the release to fail. The release tools need to be updated and we have broader plans to revamp the build tools that we use to provide more flexibility at the helm level.