### PR TITLE
Inject 'helm.sh/resource-policy: keep' into doppler-operator-system namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,10 @@ charts: manifests kustomize helm-tool yq dist
 	mkdir -p $(CHART_DIR)/crds
 	mkdir -p $(CHART_DIR)/templates
 	$(YQ) e 'select(.kind == "CustomResourceDefinition")' dist/recommended.yaml > $(CHART_DIR)/crds/all.yaml
-	$(YQ) e 'select(.kind != "CustomResourceDefinition")' dist/recommended.yaml > $(CHART_DIR)/templates/all.yaml
+	# Inject 'helm.sh/resource-policy: keep' into doppler-operator-system namespace to prevent it from being destroyed if chart is uninstalled.
+	# This will also allow future versions of the chart to remove this resource entirely.
+	$(YQ) e 'select(.kind == "Namespace") | .metadata.annotations."helm.sh/resource-policy" = "keep"' dist/recommended.yaml > $(CHART_DIR)/templates/namespace.yaml
+	$(YQ) e 'select(.kind != "CustomResourceDefinition" and .kind != "Namespace")' dist/recommended.yaml > $(CHART_DIR)/templates/all.yaml
 	cp hack/helm/Chart.yaml $(CHART_DIR)/
 	cp hack/helm/NOTES.txt $(CHART_DIR)/templates/
 	touch $(CHART_DIR)/values.yaml


### PR DESCRIPTION
The DKO Helm chart automatically generates the `doppler-operator-system` namespace during installation. We'd like to start respecting the Helm installation namespace in v2 of the operator but if we simply drop the `doppler-operator-system` namespace manifest from our chart, it'll be destroyed from user installations (along with any `DopplerSecret` resources and secrets inside).

We're adding `helm.sh/resource-policy: keep` to allow future versions of the chart to be upgraded or uninstalled without destroying the `doppler-operator-system` namespace.