### PR TITLE
Improve Helm chart parameterization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           go-version: "1.24"
 
       - name: Generate Helm Chart and Recommended YAML
-        run: make dist charts
+        run: make dist helm
         env:
           VERSION: ${{ steps.extract.outputs.version }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 as builder
+FROM golang:1.24 AS builder
 
 ARG CONTROLLER_VERSION
 ARG TARGETOS

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+- manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -8,13 +8,6 @@ spec:
     spec:
       containers:
       - name: manager
-        args:
-        - "--config=controller_manager_config.yaml"
-        volumeMounts:
-        - name: manager-config
-          mountPath: /controller_manager_config.yaml
-          subPath: controller_manager_config.yaml
-      volumes:
-      - name: manager-config
-        configMap:
-          name: manager-config
+        envFrom:
+        - configMapRef:
+            name: controller-manager-config

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,9 +5,9 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- files:
-  - controller_manager_config.yaml
-  name: manager-config
+- literals:
+  - CLUSTER_DOPPLERSECRET_NAMESPACE=doppler-operator-system
+  name: controller-manager-config
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/config/samples/secrets_v1alpha1_dopplersecret.yaml
+++ b/config/samples/secrets_v1alpha1_dopplersecret.yaml
@@ -9,3 +9,6 @@ spec:
   managedSecret: # Kubernetes managed secret (will be created if does not exist)
     name: doppler-test-secret
     namespace: default # Should match the namespace of deployments that will use the secret
+  # project and config may be omitted if using a service token
+  project: backend
+  config: prd

--- a/controllers/dopplersecret_controller_util.go
+++ b/controllers/dopplersecret_controller_util.go
@@ -17,28 +17,12 @@ limitations under the License.
 package controllers
 
 import (
-	"fmt"
-	"io/ioutil"
 	"os"
-	"strings"
 )
 
-func GetOwnNamespace() (string, error) {
-	// Adapted from https://github.com/kubernetes/kubernetes/pull/63707
-
-	// This way assumes you've set the POD_NAMESPACE environment variable using the downward API.
-	// This check has to be done first for backwards compatibility with the way InClusterConfig was originally set up
-	if ns, ok := os.LookupEnv("POD_NAMESPACE"); ok {
-		return ns, nil
+func GetClusterNamespace() string {
+	if ns, ok := os.LookupEnv("CLUSTER_DOPPLERSECRET_NAMESPACE"); ok {
+		return ns
 	}
-
-	// Fall back to the namespace associated with the service account token, if available
-	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
-		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-			return ns, nil
-		}
-		return "", fmt.Errorf("Failed to find current namespace for the operator: %w", err)
-	} else {
-		return "", err
-	}
+	return ""
 }

--- a/docs/migrating_from_1_to_2.md
+++ b/docs/migrating_from_1_to_2.md
@@ -1,0 +1,21 @@
+# Migrating from v1 to v2
+
+Doppler Kubernetes Operator (DKO) v1 shipped with a very simple Helm chart; it did not support any custom values and it ignored the namespace provided by the user during `helm install`. The v1 chart created the `doppler-operator-system` namespace and installed all resources here.
+
+Doppler Kubernetes Operator (DKO) v2 makes the Helm chart much more flexible but a few things must be considered when upgrading from v1 to v2.
+
+**Will any resources be moved to the Helm installation namespace when I upgrade?**
+
+If you installed the DKO Helm v1 chart in a namespace other than `doppler-operator-system`, the operator manager deployment ignored this configuration and was installed in the `doppler-operator-system` namespace. When you upgrade to the v2 chart, the deployment will be moved to the Helm installation namespace.
+
+For example, if you followed the steps in our README to install DKO v1 (`helm install --generate-name doppler/doppler-kubernetes-operator`), the chart was installed in the `default` namespace and this is where the operator will move when you upgrade.
+
+**I want the operator to continue running from `doppler-operator-system` but I installed the Helm chart in a different namespace.**
+
+If you have installed the DKO Helm chart in a namespace other than `doppler-operator-system` but you want to keep the operator manager deployment running in `doppler-operator-system`, there is a migration path. First, upgrade to v1.6.1 to ensure that the `doppler-operator-system` namespace is marked with the `helm.sh/resource-policy: keep` annotation. This will allow you to uninstall the DKO Helm chart without destroying the `doppler-operator-system` namespace (and any `DopplerSecret` resources inside). You can then uninstall and reinstall the DKO Helm chart with version v2.0.0 (or any later version) in the `doppler-operator-system` namespace.
+
+**`DopplerSecret` resources in the `doppler-operator-system` namespace have special permissions behavior, will this be preserved?**
+
+In DKO v1, the operator manager treated `DopplerSecret` resources its own namespace (`doppler-operator-system`) with special permissions. `DopplerSecret` resources in this namespace were allowed to reference token and managed secrets anywhere in the cluster. `DopplerSecret` resources outside of this namespace could only reference token and managed secrets in the same namespace as the `DopplerSecret`.
+
+In DKO v2, this special namespace definition has been moved to the `controllerManagerConfig.clusterDopplersecretNamespace` Helm value, with the default set to `doppler-operator-system`. This means that when you upgrade to v2, the `doppler-operator-system` namespace permissions behavior will be preserved, regardless of where the operator is running. You can choose to modify Helm value to change the cluster namespace or you can set it to the empty string (`""`) to disable the cluster permissions behavior entirely.

--- a/hack/helm/NOTES.txt
+++ b/hack/helm/NOTES.txt
@@ -1,1 +1,0 @@
-To configure the Doppler operator, see https://github.com/DopplerHQ/kubernetes-operator

--- a/hack/helm/cluster-dopplersecret-namespace.yaml
+++ b/hack/helm/cluster-dopplersecret-namespace.yaml
@@ -1,0 +1,8 @@
+{{- if eq .Values.controllerManagerConfig.clusterDopplersecretNamespace "doppler-operator-system" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: doppler-operator-system
+  annotations:
+    "helm.sh/resource-policy": keep
+{{- end }}

--- a/tools/operator-logs.sh
+++ b/tools/operator-logs.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
-OPERATOR_NAMESPACE=doppler-operator-system
-OPERATOR_MANAGER=doppler-operator-controller-manager
 
-kubectl rollout status -w -n $OPERATOR_NAMESPACE deployment/$OPERATOR_MANAGER
-kubectl logs -f -n $OPERATOR_NAMESPACE deployments/$OPERATOR_MANAGER -c manager
+DEPLOYMENT_OPTIONS="$(kubectl get deployments -A -l 'control-plane=controller-manager' -o go-template --template='{{range .items}}{{.metadata.namespace}}/{{.metadata.name}}{{end}}')"
+option_count=$(echo "$DEPLOYMENT_OPTIONS" | grep -c .)
+
+if [ -z "$1" ]; then
+  if [ "$option_count" -eq 0 ]; then
+    echo "No deployments found with the specified label."
+    exit 1
+  elif [ "$option_count" -eq 1 ]; then
+    OPERATOR_MANAGER="$DEPLOYMENT_OPTIONS"
+  else
+    if command -v fzf >/dev/null 2>&1; then
+      OPERATOR_MANAGER=$(echo "$DEPLOYMENT_OPTIONS" | fzf --prompt="Select an operator deployment: ")
+      if [ -z "$OPERATOR_MANAGER" ]; then
+        echo "No selection made."
+        exit 1
+      fi
+    else
+      echo "Error: Multiple deployments found but 'fzf' is not installed to select one."
+      echo "$DEPLOYMENT_OPTIONS"
+      exit 1
+    fi
+  fi
+else
+  OPERATOR_MANAGER="$1"
+fi
+
+echo "Found $OPERATOR_MANAGER"
+IFS="/" read -r OPERATOR_NAMESPACE OPERATOR_DEPLOYMENT <<<"$OPERATOR_MANAGER"
+
+kubectl rollout status -w -n "$OPERATOR_NAMESPACE" "deployment/$OPERATOR_DEPLOYMENT"
+kubectl logs -f -n "$OPERATOR_NAMESPACE" "deployments/$OPERATOR_DEPLOYMENT" -c manager


### PR DESCRIPTION
These changes use [helmify](https://github.com/arttor/helmify) to generate Helm charts that are much more flexible than what we have today. Here is the new `values.yaml`:

```
controllerManager:
  manager:
    args:
    - --health-probe-bind-address=:8081
    - --metrics-bind-address=127.0.0.1:8080
    - --leader-elect
    containerSecurityContext:
      allowPrivilegeEscalation: false
      capabilities:
        drop:
        - NET_RAW
      privileged: false
      runAsNonRoot: true
    image:
      repository: dopplerhq/kubernetes-operator
      tag: 1.6.0
    resources:
      limits:
        cpu: 100m
        memory: 256Mi
      requests:
        cpu: 100m
        memory: 256Mi
  podLabels: {}
  podSecurityContext:
    runAsNonRoot: true
  replicas: 1
  serviceAccount:
    annotations: {}
controllerManagerConfig:
  clusterDopplersecretNamespace: doppler-operator-system
kubernetesClusterDomain: cluster.local
```

This will require a major upgrade to the DKO (v2) as there are some things for users to consider during the upgrade.