### PR TITLE
Add OIDC authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,20 @@ You can verify that the operator is running successfully in your cluster with `.
 
 A `DopplerSecret` is a custom Kubernetes resource with references to two secrets:
 
-- A Kubernetes secret where your Doppler Service Token is stored (AKA "Doppler Token Secret"). This token will be used to fetch secrets from your Doppler config. The operator will be looking for the token in the `serviceToken` field of this secret.
+- A Kubernetes secret containing either your Doppler Service Token (in the `serviceToken` field) OR OIDC configuration (in the `identity` field) for authentication (AKA "Doppler Token Secret")
 - A Kubernetes secret where your synced Doppler secrets will be stored (AKA "Managed Secret"). This secret will be created by the operator if it does not already exist.
 
 > Note: While these resources can be created in any namespace, it is recommended that you create your Doppler Token Secret and DopplerSecret inside the `doppler-operator-system` namespace to prevent unauthorized access. The managed secret should be namespaced with the deployments which will use the secret.
 
-Generate a Doppler Service Token and use it in this command to create your Doppler token secret:
+### Authentication Setup
+
+The operator supports two authentication methods: Service Token and OIDC.
+
+Configure either a Workplace Role or a set of Project Access permissions on your Doppler Service Account to allow the appropriate access.
+
+#### Option 1: Service Token Authentication
+
+Generate a Doppler Service Token and create a secret:
 
 ```bash
 kubectl create secret generic doppler-token-secret -n doppler-operator-system --from-literal=serviceToken=dp.st.dev.XXXX
@@ -74,10 +82,26 @@ kubectl create secret generic doppler-token-secret -n doppler-operator-system --
 If you have the Doppler CLI installed, you can generate a Doppler Service Token from the CLI and create the Doppler token secret in one step:
 
 ```bash
-kubectl create secret generic doppler-token-secret -n doppler-operator-system --from-literal=serviceToken=$(doppler configs tokens create doppler-kubernetes-operator --plain)
+kubectl create secret generic doppler-token-secret -n doppler-operator-system --from-literal=serviceToken=$(doppler configs tokens create doppler-kubernetes-operator --project example-project --config prd --plain)
 ```
 
-Next, we'll create a `DopplerSecret` that references your Doppler token secret and defines the location of the managed secret.
+#### Option 2: OIDC Authentication
+
+First, ensure your cluster's OIDC discovery URLs are publicly accessible. Then create a Doppler [Service Account Identity](https://docs.doppler.com/docs/service-account-identities) with:
+
+- **Audience**: `dopplerTokenSecret:doppler-operator-system:doppler-token-secret`, where `doppler-token-secret` is the name of the secret created in the next step, and `doppler-operator-system` is the namespace.
+  - Alternatively, you may specify an audience claim of `https://api.doppler.com` if you would like any token issued by the cluster to the `doppler-operator-controller-manager` service account to be able to authenticate using this identity.
+- **Subject**: `system:serviceaccount:doppler-operator-system:doppler-operator-controller-manager`, the operator's shared ServiceAccount.
+
+Create a secret containing your OIDC configuration:
+
+```bash
+kubectl create secret generic doppler-token-secret -n doppler-operator-system --from-literal=identity=YOUR_IDENTITY_ID
+```
+
+### Creating the DopplerSecret
+
+Next, create a `DopplerSecret` that references your authentication secret and defines the location of the managed secret:
 
 ```yaml
 apiVersion: secrets.doppler.com/v1alpha1
@@ -86,8 +110,10 @@ metadata:
   name: dopplersecret-test # DopplerSecret Name
   namespace: doppler-operator-system
 spec:
-  tokenSecret: # Kubernetes service token secret (namespace defaults to doppler-operator-system)
+  tokenSecret: # References the auth secret created above
     name: doppler-token-secret
+  project: example-project # Doppler project
+  config: prd # Doppler config
   managedSecret: # Kubernetes managed secret (will be created if does not exist)
     name: doppler-test-secret
     namespace: default # Should match the namespace of deployments that will use the secret
@@ -98,6 +124,8 @@ If you're following along with these example names, you can apply this sample di
 ```bash
 kubectl apply -f config/samples/secrets_v1alpha1_dopplersecret.yaml
 ```
+
+### Verify Secret Creation
 
 Check that the associated Kubernetes secret has been created:
 

--- a/api/v1alpha1/dopplersecret_types.go
+++ b/api/v1alpha1/dopplersecret_types.go
@@ -76,7 +76,7 @@ var DefaultProcessor = SecretProcessor{Type: "plain"}
 
 // DopplerSecretSpec defines the desired state of DopplerSecret
 type DopplerSecretSpec struct {
-	// The Kubernetes secret containing the Doppler service token
+	// The Kubernetes secret containing either a Doppler service token or OIDC configuration
 	TokenSecretRef TokenSecretReference `json:"tokenSecret,omitempty"`
 
 	// The Kubernetes secret where the operator will store and sync the fetched secrets

--- a/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
+++ b/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
@@ -138,8 +138,8 @@ spec:
                   type: string
                 type: array
               tokenSecret:
-                description: The Kubernetes secret containing the Doppler service
-                  token
+                description: The Kubernetes secret containing either a Doppler service
+                  token or OIDC configuration
                 properties:
                   name:
                     description: The name of the Secret resource

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -16,6 +16,12 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/config/samples/secrets_v1alpha1_dopplersecret.yaml
+++ b/config/samples/secrets_v1alpha1_dopplersecret.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   tokenSecret: # Kubernetes service token secret (namespace defaults to doppler-operator-system)
     name: doppler-token-secret
+  project: example-project # Doppler project
+  config: prd # Doppler config
   managedSecret: # Kubernetes managed secret (will be created if does not exist)
     name: doppler-test-secret
     namespace: default # Should match the namespace of deployments that will use the secret

--- a/controllers/dopplersecret_controller_auth.go
+++ b/controllers/dopplersecret_controller_auth.go
@@ -1,0 +1,144 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	secretsv1alpha1 "github.com/DopplerHQ/kubernetes-operator/api/v1alpha1"
+	"github.com/DopplerHQ/kubernetes-operator/pkg/api"
+	"github.com/DopplerHQ/kubernetes-operator/pkg/auth"
+)
+
+// Interface for different authentication methods
+type AuthProvider interface {
+	GetAPIContext(ctx context.Context) (*api.APIContext, error)
+}
+
+// Handle service token authentication
+type ServiceTokenAuthProvider struct {
+	client    client.Client
+	tokenRef  *secretsv1alpha1.TokenSecretReference
+	namespace string
+	host      string
+	verifyTLS bool
+}
+
+func (s *ServiceTokenAuthProvider) GetAPIContext(ctx context.Context) (*api.APIContext, error) {
+	tokenSecret := corev1.Secret{}
+	tokenNamespace := s.namespace
+	if s.tokenRef.Namespace != "" {
+		tokenNamespace = s.tokenRef.Namespace
+	}
+
+	err := s.client.Get(ctx, types.NamespacedName{
+		Name:      s.tokenRef.Name,
+		Namespace: tokenNamespace,
+	}, &tokenSecret)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch token secret: %w", err)
+	}
+
+	serviceToken, ok := tokenSecret.Data["serviceToken"]
+	if !ok {
+		return nil, fmt.Errorf("token secret does not contain 'serviceToken' field")
+	}
+
+	return &api.APIContext{
+		Host:      s.host,
+		APIKey:    string(serviceToken),
+		VerifyTLS: s.verifyTLS,
+	}, nil
+}
+
+// Handle OIDC authentication
+type OIDCAuthProvider struct {
+	oidcProvider *auth.OIDCAuthProvider
+	host         string
+	verifyTLS    bool
+}
+
+func (o *OIDCAuthProvider) GetAPIContext(ctx context.Context) (*api.APIContext, error) {
+	token, err := o.oidcProvider.GetToken(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get OIDC token: %w", err)
+	}
+
+	return &api.APIContext{
+		Host:      o.host,
+		APIKey:    token,
+		VerifyTLS: o.verifyTLS,
+	}, nil
+}
+
+// Determine which authentication provider to use
+func (r *DopplerSecretReconciler) getAuthProvider(ctx context.Context, dopplerSecret *secretsv1alpha1.DopplerSecret) (AuthProvider, error) {
+	// Ensure only one auth method is specced
+	if dopplerSecret.Spec.OIDCAuth != nil && dopplerSecret.Spec.TokenSecretRef != nil {
+		return nil, fmt.Errorf("cannot specify both 'oidcAuth' and 'tokenSecret' fields - use one or the other")
+	}
+
+	// Check for OIDC auth config
+	if dopplerSecret.Spec.OIDCAuth != nil {
+		return r.createOIDCAuthProvider(ctx, dopplerSecret)
+	}
+
+	// Check for TokenSecretRef field
+	if dopplerSecret.Spec.TokenSecretRef != nil {
+		return &ServiceTokenAuthProvider{
+			client:    r.Client,
+			tokenRef:  dopplerSecret.Spec.TokenSecretRef,
+			namespace: dopplerSecret.Namespace,
+			host:      dopplerSecret.Spec.Host,
+			verifyTLS: dopplerSecret.Spec.VerifyTLS,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("no authentication method configured")
+}
+
+// Create an OIDC authentication provider
+func (r *DopplerSecretReconciler) createOIDCAuthProvider(ctx context.Context, dopplerSecret *secretsv1alpha1.DopplerSecret) (AuthProvider, error) {
+	oidcConfig := dopplerSecret.Spec.OIDCAuth
+
+	// Create kubernetes clientset for TokenRequest API
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get kubernetes config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create kubernetes clientset: %w", err)
+	}
+
+	// Determine service account namespace
+	saNamespace := dopplerSecret.Namespace
+	if oidcConfig.ServiceAccountRef.Namespace != "" {
+		saNamespace = oidcConfig.ServiceAccountRef.Namespace
+	}
+
+	// Use configured TTL
+	tokenTTL := time.Duration(*oidcConfig.ExpirationSeconds) * time.Second
+
+	authConfig := auth.OIDCConfig{
+		ServiceAccountName: oidcConfig.ServiceAccountRef.Name,
+		Namespace:          saNamespace,
+		Audiences:          oidcConfig.Audiences,
+		IdentityID:         oidcConfig.IdentityID,
+		TokenTTL:           tokenTTL,
+	}
+
+	oidcProvider := auth.NewOIDCAuthProvider(clientset, authConfig, dopplerSecret.Spec.Host, dopplerSecret.Spec.VerifyTLS)
+
+	return &OIDCAuthProvider{
+		oidcProvider: oidcProvider,
+		host:         dopplerSecret.Spec.Host,
+		verifyTLS:    dopplerSecret.Spec.VerifyTLS,
+	}, nil
+}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -1,0 +1,175 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Handle OIDC-based authentication
+type OIDCAuthProvider struct {
+	// Kubernetes client for TokenRequest API
+	kubeClient kubernetes.Interface
+
+	Namespace string
+	Audiences []string
+
+	Host              string
+	Identity          string
+	VerifyTLS         bool
+	ExpirationSeconds int64
+
+	// Token management
+	rwm         sync.RWMutex
+	cachedToken string
+	tokenExpiry time.Time
+}
+
+
+// Returns a Doppler API token, refreshing if necessary
+func (o *OIDCAuthProvider) GetToken(ctx context.Context) (string, error) {
+	o.rwm.RLock()
+	if o.isTokenValid() {
+		token := o.cachedToken
+		o.rwm.RUnlock()
+		return token, nil
+	}
+	o.rwm.RUnlock()
+
+	// Token needs refresh
+	return o.refreshToken(ctx)
+}
+
+// Check if the cached token is still valid
+func (o *OIDCAuthProvider) isTokenValid() bool {
+	if o.cachedToken == "" {
+		return false
+	}
+	return time.Until(o.tokenExpiry) > 60*time.Second
+}
+
+// Obtain a new Doppler Service Account API token
+func (o *OIDCAuthProvider) refreshToken(ctx context.Context) (string, error) {
+	o.rwm.Lock()
+	defer o.rwm.Unlock()
+
+	// Sanity check after acquiring write lock
+	if o.isTokenValid() {
+		return o.cachedToken, nil
+	}
+
+	saToken, err := o.getServiceAccountToken(ctx)
+	if err != nil {
+		return "", fmt.Errorf("Failed to get service account token: %w", err)
+	}
+
+	dopplerToken, expiry, err := o.exchangeTokenWithDoppler(ctx, saToken)
+	if err != nil {
+		return "", fmt.Errorf("Failed to exchange token with Doppler: %w", err)
+	}
+
+	o.cachedToken = dopplerToken
+	o.tokenExpiry = expiry
+
+	return dopplerToken, nil
+}
+
+// Use the TokenRequest API to get a JWT
+func (o *OIDCAuthProvider) getServiceAccountToken(ctx context.Context) (string, error) {
+	tokenRequest := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			Audiences:         o.Audiences,
+			ExpirationSeconds: &o.ExpirationSeconds,
+		},
+	}
+
+	tokenResponse, err := o.kubeClient.CoreV1().
+		ServiceAccounts(o.Namespace).
+		CreateToken(ctx, "doppler-operator-controller-manager", tokenRequest, metav1.CreateOptions{})
+
+	if err != nil {
+		return "", fmt.Errorf("Failed to create service account token: %w", err)
+	}
+
+	return tokenResponse.Status.Token, nil
+}
+
+// Exchange the K8s SA token for a Doppler SA API Token
+func (o *OIDCAuthProvider) exchangeTokenWithDoppler(ctx context.Context, saToken string) (string, time.Time, error) {
+	url := fmt.Sprintf("%s/v3/auth/oidc", o.Host)
+
+	requestBody := map[string]string{
+		"identity": o.Identity,
+		"token":    saToken,
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("Failed to marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("Failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: !o.VerifyTLS,
+		},
+	}
+
+	client := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: transport,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("Failed to make request to Doppler: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("Failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", time.Time{}, fmt.Errorf("Doppler OIDC auth failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var response struct {
+		Success   bool   `json:"success"`
+		Token     string `json:"token"`
+		ExpiresAt string `json:"expires_at"`
+	}
+
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", time.Time{}, fmt.Errorf("Failed to parse response: %w", err)
+	}
+
+	if !response.Success {
+		return "", time.Time{}, fmt.Errorf("Doppler OIDC auth failed")
+	}
+
+	expiresAt, err := time.Parse(time.RFC3339, response.ExpiresAt)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("Failed to parse expiration time: %w", err)
+	}
+
+	return response.Token, expiresAt, nil
+}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,0 +1,113 @@
+package cache
+
+import (
+	"container/list"
+	"sync"
+)
+
+type Key struct {
+	Identity string
+	// Audiences is part of the cache key because it includes the token secret's
+	// namespace and name (e.g., "dopplerTokenSecret:namespace:secret-name").
+	// This allows the same identity to be used in different token secrets
+	// (different names or namespaces) while maintaining separate cached providers
+	// for each, since each will have different audience claims in their JWTs.
+	Audiences string
+}
+
+type Cache[T any] struct {
+	mu      sync.RWMutex
+	items   map[Key]*list.Element
+	lruList *list.List
+	maxSize int
+	onEvict func(T)
+}
+
+type cacheEntry[T any] struct {
+	key   Key
+	value T
+}
+
+func New[T any](maxSize int, onEvict func(T)) *Cache[T] {
+	return &Cache[T]{
+		items:   make(map[Key]*list.Element),
+		lruList: list.New(),
+		maxSize: maxSize,
+		onEvict: onEvict,
+	}
+}
+
+func (c *Cache[T]) Get(key Key) (T, bool) {
+	if c.maxSize == 0 {
+		var zero T
+		return zero, false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, exists := c.items[key]; exists {
+		entry := elem.Value.(*cacheEntry[T])
+		c.lruList.MoveToFront(elem)
+		return entry.value, true
+	}
+
+	var zero T
+	return zero, false
+}
+
+func (c *Cache[T]) Add(key Key, value T) {
+	if c.maxSize == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, exists := c.items[key]; exists {
+		entry := elem.Value.(*cacheEntry[T])
+		entry.value = value
+		c.lruList.MoveToFront(elem)
+		return
+	}
+
+	// Add new entry
+	entry := &cacheEntry[T]{
+		key:   key,
+		value: value,
+	}
+	elem := c.lruList.PushFront(entry)
+	c.items[key] = elem
+
+	// Check if we need to evict
+	if c.lruList.Len() > c.maxSize {
+		c.evictOldest()
+	}
+}
+
+func (c *Cache[T]) Remove(key Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if elem, exists := c.items[key]; exists {
+		c.removeElement(elem)
+	}
+}
+
+// Remove element from cache
+func (c *Cache[T]) removeElement(elem *list.Element) {
+	entry := elem.Value.(*cacheEntry[T])
+	delete(c.items, entry.key)
+	c.lruList.Remove(elem)
+	if c.onEvict != nil {
+		c.onEvict(entry.value)
+	}
+}
+
+// Remove the least recently used item
+func (c *Cache[T]) evictOldest() {
+	elem := c.lruList.Back()
+	if elem != nil {
+		c.removeElement(elem)
+	}
+}


### PR DESCRIPTION
This PR adds the ability to authenticate using OIDC as an alternative to static Doppler service tokens.

OIDC Authentication Flow:
1. We generate a temporary Kubernetes ServiceAccount JWT using the TokenRequest API.
2. The generated token is exchanged with our OIDC endpoint for an API token (with the TTL specified in the Service Account Identity). 
3. The Doppler API token is cached and used for all API requests to fetch secrets.
4. We refresh the cached token with <60 seconds remaining in the TTL.

The token caching uses a read/write mutual exclusion lock (any number of readers, only one writer) https://pkg.go.dev/sync#RWMutex

I've tested with AWS EKS in addition to a hacky local minikube oidc issuer.

I'm still making some final updates to the readme formatting so please feel free to make suggestions for clarity's sake.