### PR TITLE
Add excludeSecretsRegex field to filter secrets during sync

### DIFF
--- a/api/v1alpha1/dopplersecret_types.go
+++ b/api/v1alpha1/dopplersecret_types.go
@@ -94,6 +94,10 @@ type DopplerSecretSpec struct {
 	// +optional
 	Secrets []string `json:"secrets,omitempty"`
 
+	// Regex pattern to exclude secrets that match this pattern from being synced
+	// +optional
+	ExcludeSecretsRegex string `json:"excludeSecretsRegex,omitempty"`
+
 	// A list of processors to transform the data during ingestion
 	// +kubebuilder:default={}
 	Processors SecretProcessors `json:"processors,omitempty"`

--- a/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
+++ b/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
@@ -42,6 +42,10 @@ spec:
               config:
                 description: The Doppler config
                 type: string
+              excludeSecretsRegex:
+                description: Regex pattern to exclude secrets that match this pattern
+                  from being synced
+                type: string
               format:
                 description: Format enables the downloading of secrets as a file
                 enum:

--- a/config/samples/secrets_v1alpha1_dopplersecret_with_exclude_regex.yaml
+++ b/config/samples/secrets_v1alpha1_dopplersecret_with_exclude_regex.yaml
@@ -1,0 +1,13 @@
+apiVersion: secrets.doppler.com/v1alpha1
+kind: DopplerSecret
+metadata:
+  name: dopplersecret-exclude-regex-example
+  namespace: doppler-operator-system
+spec:
+  tokenSecret:
+    name: doppler-token-secret
+  managedSecret:
+    name: doppler-test-secret-filtered
+    namespace: default
+  # Exclude secrets that start with "TEMP_", contain "DEBUG", or end with "_TEST"
+  excludeSecretsRegex: "^TEMP_.*|.*DEBUG.*|.*_TEST$"


### PR DESCRIPTION
## Summary
- Add `excludeSecretsRegex` field to `DopplerSecretSpec`
- Implement regex filtering in `GetKubeSecretData` function 
- Add validation and error handling for invalid regex patterns
- Update CRDs with the new optional field
- Add example configuration for regex exclusion

## Description

This PR adds the ability to exclude secrets from being synced based on a regex pattern. The new `excludeSecretsRegex` field allows users to specify a regular expression that will filter out secrets matching the pattern before they are stored in the managed Kubernetes secret.

## Features Added

- **Optional regex filtering**: New `excludeSecretsRegex` field in DopplerSecret spec
- **Validation**: Invalid regex patterns are caught and reported with clear error messages  
- **Backward compatibility**: Field is optional, existing DopplerSecrets continue to work unchanged
- **Example configuration**: Added sample YAML showing how to use the new field

## Testing

- ✅ Tested with real Doppler project (`cryptonets/dev_falcon`)
- ✅ Verified filtering works correctly (excluded 3 ARGOCD_* secrets)
- ✅ Verified backward compatibility (no filter = all secrets synced)
- ✅ Tested invalid regex patterns return appropriate errors

## Example Usage

```yaml
apiVersion: secrets.doppler.com/v1alpha1
kind: DopplerSecret
metadata:
  name: filtered-secret
spec:
  tokenSecret:
    name: doppler-token-secret
  managedSecret:
    name: my-secret
    namespace: default
  # Exclude secrets starting with TEMP_ or containing _DEBUG
  excludeSecretsRegex: "^TEMP_.*|.*_DEBUG.*"
```

## Test plan

- [x] Build and test locally
- [x] Verify CRDs are generated correctly
- [x] Test with real Doppler secrets
- [x] Verify regex validation works
- [x] Test backward compatibility