### PR TITLE
Export `KubeClient` field in `OIDCAuthProvider` struct

### DIFF
--- a/controllers/dopplersecret_controller_auth.go
+++ b/controllers/dopplersecret_controller_auth.go
@@ -203,7 +203,7 @@ func (r *DopplerSecretReconciler) createOIDCAuthProvider(dopplerSecret *secretsv
 		}
 
 		oidcProvider = &auth.OIDCAuthProvider{
-			kubeClient:        clientset,
+			KubeClient:        clientset,
 			Namespace:         operatorNamespace,
 			Audiences:         audiences,
 			Host:              dopplerSecret.Spec.Host,

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -19,7 +19,7 @@ import (
 // Handle OIDC-based authentication
 type OIDCAuthProvider struct {
 	// Kubernetes client for TokenRequest API
-	kubeClient kubernetes.Interface
+	KubeClient kubernetes.Interface
 
 	Namespace string
 	Audiences []string
@@ -93,7 +93,7 @@ func (o *OIDCAuthProvider) getServiceAccountToken(ctx context.Context) (string, 
 		},
 	}
 
-	tokenResponse, err := o.kubeClient.CoreV1().
+	tokenResponse, err := o.KubeClient.CoreV1().
 		ServiceAccounts(o.Namespace).
 		CreateToken(ctx, "doppler-operator-controller-manager", tokenRequest, metav1.CreateOptions{})
 


### PR DESCRIPTION
This PR includes a fix which was meant to be part of force-pushed changes to [pr 89](https://github.com/DopplerHQ/kubernetes-operator/pull/89) but unintentionally ended up being stashed.