### PR TITLE
Add support for specifying OIDC identity in DopplerSecret spec

### DIFF
--- a/api/v1alpha1/dopplersecret_types.go
+++ b/api/v1alpha1/dopplersecret_types.go
@@ -75,12 +75,22 @@ type SecretProcessors map[string]*SecretProcessor
 var DefaultProcessor = SecretProcessor{Type: "plain"}
 
 // DopplerSecretSpec defines the desired state of DopplerSecret
+// +kubebuilder:validation:XValidation:rule="(has(self.tokenSecret) && !has(self.identity)) || (!has(self.tokenSecret) && has(self.identity))",message="Must specify either tokenSecret or identity, but not both"
 type DopplerSecretSpec struct {
-	// The Kubernetes secret containing either a Doppler service token or OIDC configuration
+	// The Kubernetes secret containing either a Doppler service token or OIDC configuration. Mutually exclusive with 'identity'.
+	// +optional
 	TokenSecretRef TokenSecretReference `json:"tokenSecret,omitempty"`
 
 	// The Kubernetes secret where the operator will store and sync the fetched secrets
 	ManagedSecretRef ManagedSecretReference `json:"managedSecret,omitempty"`
+
+	// The Doppler Service Account Identity (OIDC). Mutually exclusive with 'tokenSecret'.
+	// +optional
+	Identity string `json:"identity,omitempty"`
+
+	// The JWT expiration time in seconds for OIDC authentication. This controls the lifetime of the Kubernetes ServiceAccount token requested via the TokenRequest API. Kubernetes enforces a minimum of 600 seconds (10 minutes). Defaults to 600 if not specified.
+	// +optional
+	ExpirationSeconds int64 `json:"expirationSeconds,omitempty"`
 
 	// The Doppler project
 	// +optional

--- a/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
+++ b/config/crd/bases/secrets.doppler.com_dopplersecrets.yaml
@@ -42,6 +42,13 @@ spec:
               config:
                 description: The Doppler config
                 type: string
+              expirationSeconds:
+                description: The JWT expiration time in seconds for OIDC authentication.
+                  This controls the lifetime of the Kubernetes ServiceAccount token
+                  requested via the TokenRequest API. Kubernetes enforces a minimum
+                  of 600 seconds (10 minutes). Defaults to 600 if not specified.
+                format: int64
+                type: integer
               format:
                 description: Format enables the downloading of secrets as a file
                 enum:
@@ -54,6 +61,10 @@ spec:
               host:
                 default: https://api.doppler.com
                 description: The Doppler API host
+                type: string
+              identity:
+                description: The Doppler Service Account Identity (OIDC). Mutually
+                  exclusive with 'tokenSecret'.
                 type: string
               managedSecret:
                 description: The Kubernetes secret where the operator will store and
@@ -139,7 +150,7 @@ spec:
                 type: array
               tokenSecret:
                 description: The Kubernetes secret containing either a Doppler service
-                  token or OIDC configuration
+                  token or OIDC configuration. Mutually exclusive with 'identity'.
                 properties:
                   name:
                     description: The name of the Secret resource
@@ -156,6 +167,10 @@ spec:
                 description: Whether or not to verify TLS
                 type: boolean
             type: object
+            x-kubernetes-validations:
+            - message: Must specify either tokenSecret or identity, but not both
+              rule: (has(self.tokenSecret) && !has(self.identity)) || (!has(self.tokenSecret)
+                && has(self.identity))
           status:
             description: DopplerSecretStatus defines the observed state of DopplerSecret
             properties:


### PR DESCRIPTION
This PR adds the ability to specify OIDC authentication credentials directly in the `DopplerSecret` spec as an alternative to using a `tokenSecret`.

- Maintains backward compatibility.
- Adds `identity` field to `DopplerSecret` spec.
- Adds `expirationSeconds` field to `DopplerSecret` spec since currently this value only optionally lives in the tokenSecret. This controls the lifetime of the Kubernetes ServiceAccount token requested via the TokenRequest API, and now needs to be configurable without a `tokenSecret`.
- Validates that exactly one of `tokenSecret` or `identity` is specified.