### PR TITLE
feat: add seccompProfile RuntimeDefault and drop ALL capabilities

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,6 +24,8 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -37,7 +39,9 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-              - NET_RAW
+              - ALL
+          seccompProfile:
+            type: RuntimeDefault
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary

- Add `seccompProfile: type: RuntimeDefault` to both the pod-level and container-level security contexts
- Upgrade `capabilities.drop` from `NET_RAW` to `ALL`

## Motivation

These changes are required to satisfy the Kubernetes [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) **restricted** profile. Without `seccompProfile`, clusters enforcing `restricted` PSS will block the operator pod from running.

`RuntimeDefault` uses the container runtime's built-in seccomp profile (containerd/CRI-O). It has no impact on normal operator functionality — the Doppler operator only makes standard Kubernetes API calls and does not require any unusual syscalls.

Dropping `ALL` capabilities (instead of just `NET_RAW`) is also required by the restricted PSS profile and is best practice for least-privilege containers.

## Test plan

- [ ] Deploy operator on a cluster with `pod-security.kubernetes.io/enforce: restricted` on the `doppler-operator-system` namespace — pod should start successfully
- [ ] Verify operator continues to sync DopplerSecrets correctly after the change